### PR TITLE
re-enable slack notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ The hostname is `brewcop.local`.
 
 ### Slack Notifications
 
-Currently disabled.
+When configuring the brewcop "app" in Slack, select "Incoming Webhooks",
+enable them, and select the channel in your workspace that brewcop should
+post in.  Ensure that `SLACK_WEBHOOK_URL` is set to the URL shown in the
+environment of `brewcop.py`.
 
 #### Release
 

--- a/brewcop.py
+++ b/brewcop.py
@@ -431,7 +431,7 @@ class Brewcop:
     tick_period = 0.5
 
     """Values for Technivorm Moccamaster insulated carafe"""
-    pot_tare_g = 796
+    pot_tare_g = 795
     pot_capacity_g = 1250  # 1g per mL H20
     pot_empty_thresh_g = 50
 
@@ -497,6 +497,8 @@ class Brewcop:
         self.poll_scale()
         if self.scale.weight_is_valid:
             w = self.scale.weight - self.pot_tare_g
+            if (w > -4 and w < 4): # +/-4g for variation in actual pot tare
+                w = 0
             if w < 0:
                 self.online = False
             else:


### PR DESCRIPTION
Problem: slack notifications were dropped in the rewrite.
    
Add them back, but this time use a webhook instead of the
ython SlackClient (now slack_sdk) as it's simpler, and the
interfaces we used in 2018 are now deprecated.